### PR TITLE
Add description for zsh-completions (how to use)

### DIFF
--- a/zsh/_mgem
+++ b/zsh/_mgem
@@ -1,5 +1,23 @@
 #compdef mgem
-
+#
+# DESCRIPTION
+# ==============
+#
+# Completion script for mgem (https://github.com/bovi/mgem)
+#
+# MANUAL INSTALLATION
+# ======================
+#
+# * Clone the repository:
+#
+#     git clone git://github.com/zsh-users/zsh-completions.git
+#
+# * Add the directory path into your `$fpath`:
+#
+#     fpath=(/path/to/mgem/zsh $fpath)
+#     or
+#     fpath+="/path/to/mgem/zsh"
+#
 _mgem()
 {
     local context state state_descr line ret=1


### PR DESCRIPTION
I added description of mgem zsh-completions into `_mgem` .

ref: https://github.com/bovi/mgem/pull/9