### PR TITLE
Remove mruby-string-utf8 from default gems

### DIFF
--- a/bin/mgem
+++ b/bin/mgem
@@ -92,7 +92,6 @@ CORE_GEMS = {
   'Range ext' => 'range-ext',
   'sprintf' => 'sprintf',
   'String ext' => 'string-ext',
-  'String UTF8' => 'string-utf8',
   'Struct' => 'struct',
   'Symbol ext' => 'symbol-ext',
   'Time' => 'time',


### PR DESCRIPTION
Hi @bovi.

[UTF-8 string supported in core](https://github.com/mruby/mruby/commit/798ec3aff48167b46a912587ef72361514b9133c) and `mruby-string-utf8` gem removed from `mruby/mruby`.

We couldn't build mruby with `build_config.rb` generated by `mgem config default` command till now.

So I just remove `mruby-string-utf8` from default gems.